### PR TITLE
fix memory leak

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -93,6 +93,7 @@ func fetchInstance() (Instance, error) {
 	if err != nil {
 		return instance, err
 	}
+	defer res.Body.Close()
 
 	err = json.NewDecoder(res.Body).Decode(&instance)
 	return instance, err
@@ -104,7 +105,8 @@ func fetchActivity() (Activities, error) {
 	if err != nil {
 		return activities, err
 	}
-
+	defer res.Body.Close()
+	
 	err = json.NewDecoder(res.Body).Decode(&activities)
 	return activities, err
 }


### PR DESCRIPTION
From https://pkg.go.dev/net/http

> The client must close the response body when finished with it

I see constant increasing memory for some containers, probably due to the body never being closed

<img width="702" alt="image" src="https://user-images.githubusercontent.com/22841/206323206-98ef41ed-0f75-445b-854b-b7becc4e47a1.png">

<img width="639" alt="image" src="https://user-images.githubusercontent.com/22841/206323703-de2dbd98-66b5-47c3-a300-621b96349fc8.png">

